### PR TITLE
fix: move child components from peerDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,18 +44,16 @@
     "alpha": "npm version prerelease --preid alpha && npm publish --tag alpha && git push --follow-tags",
     "release": "npm version patch && npm publish && git push --follow-tags"
   },
-  "peerDependencies": {
-    "convex": "^1.33.0",
+  "dependencies": {
     "@convex-dev/rate-limiter": "^0.3.0",
     "@convex-dev/sharded-counter": "^0.2.0",
     "@convex-dev/aggregate": "^0.2.0",
     "@convex-dev/crons": "^0.2.0"
   },
+  "peerDependencies": {
+    "convex": "^1.33.0"
+  },
   "devDependencies": {
-    "@convex-dev/aggregate": "^0.2.0",
-    "@convex-dev/crons": "^0.2.0",
-    "@convex-dev/rate-limiter": "^0.3.0",
-    "@convex-dev/sharded-counter": "^0.2.0",
     "@edge-runtime/vm": "^4.0.0",
     "@vllnt/eslint-config": "^1.0.0",
     "@vllnt/typescript": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 importers:
 
   .:
-    devDependencies:
+    dependencies:
       '@convex-dev/aggregate':
         specifier: ^0.2.0
         version: 0.2.1(convex@1.34.0)
@@ -20,6 +20,7 @@ importers:
       '@convex-dev/sharded-counter':
         specifier: ^0.2.0
         version: 0.2.0(convex@1.34.0)
+    devDependencies:
       '@edge-runtime/vm':
         specifier: ^4.0.0
         version: 4.0.4


### PR DESCRIPTION
## Summary

- Moved `@convex-dev/{rate-limiter,sharded-counter,aggregate,crons}` from `peerDependencies` to `dependencies`
- `convex` remains the sole `peerDependency` (consumer controls version)
- Users now install one package: `npm i @vllnt/convex-api-keys` — child components auto-install

Per [Convex component authoring docs](https://docs.convex.dev/components/authoring), child components are internal implementation details and should not require manual installation by consumers.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (69 tests)
- [x] `pnpm build` passes