### PR TITLE
ci: enable canary publish on push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,13 @@
 name: Publish
 
 on:
-  # TODO: uncomment after first manual publish to npm
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - "src/**"
-  #     - "package.json"
-  #     - "pnpm-lock.yaml"
-  #     - ".github/workflows/publish.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/publish.yml"
   workflow_dispatch:
     inputs:
       bump:


### PR DESCRIPTION
## Summary

Uncomments the `push:` trigger in publish.yml. After merging, every push to main that touches `src/**`, `package.json`, or `pnpm-lock.yaml` will auto-publish a canary version to npm.

## Before merging

Run manually:
```bash
git push origin v0.0.0          # baseline tag
pnpm build:clean && npm publish --access public  # first release
git tag -a v0.1.0 -m "v0.1.0" && git push origin v0.1.0
```