### PR TITLE
fix(ci): use typecheck:ci in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
       - run: pnpm lint
 
-      - run: pnpm typecheck
+      - run: pnpm typecheck:ci
 
       - run: pnpm test
 


### PR DESCRIPTION
The quality gate used `pnpm typecheck` which includes `src/test.ts` (needs vite/client types). Changed to `pnpm typecheck:ci` which uses `tsconfig.ci.json` — same as the CI workflow.