### PR TITLE
fix(types): remove stale sub-component refs causing TS2589

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,7 @@
     "release": "npm version patch && npm publish && git push --follow-tags"
   },
   "dependencies": {
-    "@convex-dev/rate-limiter": "^0.3.0",
-    "@convex-dev/sharded-counter": "^0.2.0",
-    "@convex-dev/aggregate": "^0.2.0",
-    "@convex-dev/crons": "^0.2.0"
+    "@convex-dev/sharded-counter": "^0.2.0"
   },
   "peerDependencies": {
     "convex": "^1.33.0"
@@ -89,7 +86,6 @@
     "convex",
     "api-keys",
     "authentication",
-    "rate-limiting",
     "multi-tenant",
     "convex-component"
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@convex-dev/aggregate':
-        specifier: ^0.2.0
-        version: 0.2.1(convex@1.34.0)
-      '@convex-dev/crons':
-        specifier: ^0.2.0
-        version: 0.2.0(convex@1.34.0)
-      '@convex-dev/rate-limiter':
-        specifier: ^0.3.0
-        version: 0.3.2(convex@1.34.0)
       '@convex-dev/sharded-counter':
         specifier: ^0.2.0
         version: 0.2.0(convex@1.34.0)
@@ -122,29 +113,10 @@ packages:
     resolution: {integrity: sha512-W65Gum02liMd3hmNrLmDBX1u5BmRMcunouFjLXyhxHnNY4YlK1kTxsgfflZ5XBGSnPnO0MkiUzAcoGzYrlx0RQ==}
     engines: {node: '>=18.18'}
 
-  '@convex-dev/aggregate@0.2.1':
-    resolution: {integrity: sha512-z8GeUC+cIZEgtMXecX6WTBQHNW4E2ioRsc5IkO8BWnCjgDOru/Mw8zXe9JPe35JkqDjlSVKuwxiQHKs/jaYAyA==}
-    peerDependencies:
-      convex: ^1.24.8
-
-  '@convex-dev/crons@0.2.0':
-    resolution: {integrity: sha512-JowF/DDPl8FuhXml2/0jmEa6uIKr/UK1UwP+FdbPt2BRVxACRX4CNlzDQEtHbO2p2FVKiJh4zEg8p5/YM27PEA==}
-    peerDependencies:
-      convex: ^1.24.8
-
   '@convex-dev/eslint-plugin@1.2.1':
     resolution: {integrity: sha512-2EfDq/jscJofSjZscPolVFa3SgfF2iwLtOBJdtI5C1089eHEgQ8bEuxbCVnRRuapAZxLXz17+8vHjPC4+hmyIQ==}
     peerDependencies:
       convex: ^1.31.7
-
-  '@convex-dev/rate-limiter@0.3.2':
-    resolution: {integrity: sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA==}
-    peerDependencies:
-      convex: ^1.24.8
-      react: ^18.2.0 || ^19.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   '@convex-dev/sharded-counter@0.2.0':
     resolution: {integrity: sha512-Qv1TvFXyQ60rADS1fWH01mnMDNSPfmKKowXva6WxIXGIC2ta5xvohe9TfUhXp4AT1vtOXoFgse3Z9mJB9fJlSQ==}
@@ -1067,10 +1039,6 @@ packages:
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
-  cron-parser@4.9.0:
-    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
-    engines: {node: '>=12.0.0'}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1739,10 +1707,6 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  luxon@3.7.2:
-    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
-    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2443,15 +2407,6 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  '@convex-dev/aggregate@0.2.1(convex@1.34.0)':
-    dependencies:
-      convex: 1.34.0
-
-  '@convex-dev/crons@0.2.0(convex@1.34.0)':
-    dependencies:
-      convex: 1.34.0
-      cron-parser: 4.9.0
-
   '@convex-dev/eslint-plugin@1.2.1(convex@1.34.0)(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.49.0
@@ -2461,10 +2416,6 @@ snapshots:
       - eslint
       - supports-color
       - typescript
-
-  '@convex-dev/rate-limiter@0.3.2(convex@1.34.0)':
-    dependencies:
-      convex: 1.34.0
 
   '@convex-dev/sharded-counter@0.2.0(convex@1.34.0)':
     dependencies:
@@ -3249,10 +3200,6 @@ snapshots:
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.1
-
-  cron-parser@4.9.0:
-    dependencies:
-      luxon: 3.7.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4096,8 +4043,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:

--- a/specs/history.log
+++ b/specs/history.log
@@ -1,1 +1,2 @@
 2026-03-25 | shipped | v0.2.0-production-hardening | 14h→4h | ~4h | Auth boundary, server-side secret gen, remove events+rate-limiter, input validation, pagination. 82 tests, PR #37.
+2026-03-27 | shipped | ts2589-type-depth | 1h→0.5h | ~20m | Remove 3 stale sub-component refs from _generated/api.ts + phantom deps from package.json. Fixes #38.

--- a/specs/shipped/2026-03-27-ts2589-type-depth.md
+++ b/specs/shipped/2026-03-27-ts2589-type-depth.md
@@ -1,0 +1,127 @@
+---
+title: "Fix TS2589: component types too deep"
+status: shipped
+created: 2026-03-27
+estimate: 1h
+tier: mini
+---
+
+# Fix TS2589: component types too deep
+
+## Context
+
+Registering `@vllnt/convex-api-keys` as a Convex component triggers TS2589 (type instantiation excessively deep) in the host app's generated `api.d.ts`. Root cause: `src/component/_generated/api.ts` was not regenerated after v0.2.0 removed 3 sub-components. It still declares `ComponentApi` imports for `@convex-dev/rate-limiter`, `@convex-dev/aggregate`, and `@convex-dev/crons` — none of which are used. `package.json` still lists all 3 as `dependencies`, pulling their type definitions into consumers' `node_modules`.
+
+## Codebase Impact
+
+| Area | Impact | Detail |
+|------|--------|--------|
+| `src/component/_generated/api.ts:52-57` | MODIFY | Remove 3 stale `ComponentApi` imports — keep only `shardedCounter` |
+| `package.json:53-56` | MODIFY | Remove `@convex-dev/rate-limiter`, `@convex-dev/aggregate`, `@convex-dev/crons` from `dependencies` |
+| `package.json:4` | MODIFY | Bump version (patch or prerelease) |
+| `pnpm-lock.yaml` | AFFECTED | Shrinks after removing 3 deps |
+| `src/component/convex.config.ts` | AFFECTED | Already correct — only `shardedCounter` — no change needed |
+| `src/component/_generated/component.ts` | AFFECTED | Already correct — no change needed |
+| `src/component/mutations.ts` | AFFECTED | Only imports `shardedCounter` — no change needed |
+| `src/component/queries.ts` | AFFECTED | Only imports `shardedCounter` — no change needed |
+| `CLAUDE.md` | AFFECTED | Already says "Single child component: @convex-dev/sharded-counter" — correct |
+| `README.md` | MODIFY | Remove mentions of rate-limiter/aggregate/crons if present |
+| `package.json:88` (keywords) | MODIFY | Remove `"rate-limiting"` keyword — no longer a feature |
+
+**Files:** 0 create | 3 modify | 5 affected
+**Reuse:** `pnpm build:codegen` regenerates `_generated/api.ts` correctly from current `convex.config.ts`
+**Breaking changes:** None — removing phantom types that were never accessible at runtime
+**New dependencies:** None — removing 3
+
+## User Journey
+
+1. Developer installs `@vllnt/convex-api-keys` and adds `app.use(apiKeys)` in `convex.config.ts`
+   -> Convex codegen generates host app `api.d.ts` with component types
+   -> Host app typechecks cleanly (no TS2589)
+
+2. Developer uses `action()` / `query()` / `mutation()` from `_generated/server`
+   -> TypeScript resolves through `FilterApi<...>` recursion without exceeding depth limit
+   -> IntelliSense works normally
+
+Error: Developer has cached `node_modules` from older version
+   -> `pnpm install` pulls only `@convex-dev/sharded-counter` (not 3 phantom deps)
+   -> Clean install, no stale types
+
+## Acceptance Criteria
+
+### Must Have (BLOCKING)
+
+- [ ] AC-1: GIVEN a host app with `app.use(apiKeys)` WHEN running `npx convex dev` and `tsc --noEmit` THEN typecheck passes without TS2589
+- [ ] AC-2: GIVEN `src/component/_generated/api.ts` WHEN inspecting `components` export THEN only `shardedCounter` is declared
+- [ ] AC-3: GIVEN `package.json` WHEN inspecting `dependencies` THEN only `@convex-dev/sharded-counter` is listed
+
+### Error Criteria (BLOCKING)
+
+- [ ] AC-E1: GIVEN existing tests WHEN running `pnpm test` THEN all tests pass (no regressions from dep removal)
+
+### Should Have
+
+- [ ] AC-4: GIVEN `package.json` keywords WHEN inspecting THEN `"rate-limiting"` is removed (no longer a feature)
+
+## Scope
+
+- [ ] 1. Regenerate `_generated/api.ts` via `pnpm build:codegen` -> AC-1, AC-2
+- [ ] 2. Remove 3 phantom deps from `package.json` dependencies -> AC-3
+- [ ] 3. Remove stale keyword from `package.json` -> AC-4
+- [ ] 4. Run `pnpm install` to update lockfile -> AC-3
+- [ ] 5. Verify existing tests pass -> AC-E1
+- [ ] 6. Check README.md for stale sub-component references -> AC-1
+
+### Out of Scope
+
+- Version bump (separate release step)
+- Host app integration test (manual verification by maintainer)
+- Example app `_generated/` cleanup (separate concern, uses `AnyApi` escape hatch)
+
+## Quality Checklist
+
+### Blocking
+
+- [ ] All Must Have ACs passing
+- [ ] All Error Criteria ACs passing
+- [ ] All scope items implemented
+- [ ] No regressions in existing tests
+- [ ] `pnpm build:codegen` succeeds
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint` passes
+
+### Advisory
+
+- [ ] `pnpm-lock.yaml` shrinks (fewer transitive deps)
+- [ ] Code follows existing project patterns
+
+## Test Strategy
+
+Runner: vitest 3.0.0 (edge-runtime) | E2E: none (backend component library) | TDD: verify existing tests pass
+AC-1 -> manual: `pnpm build:codegen && pnpm typecheck` | AC-2 -> inspect file | AC-3 -> inspect package.json | AC-E1 -> `pnpm test`
+Mocks: none (convex-test provides in-memory DB)
+
+## Analysis
+
+**Assumptions:** Stale `_generated/api.ts` is sole cause -> VALID (grep confirms only file referencing removed packages; `convex.config.ts` and `component.ts` already correct) | `pnpm build:codegen` regenerates correctly -> VALID (script runs `convex codegen --component-dir ./src/component` which reads current `convex.config.ts`) | No source code uses removed packages -> VALID (grep shows zero imports outside `_generated/api.ts`)
+**Blind Spots:** [ops] Published npm tarball includes `src/` — consumers may resolve stale `_generated/api.ts` from cache until new version published. Impact: fix only takes effect after publish.
+**Failure Hypothesis:** IF `pnpm build:codegen` also requires the removed packages installed to generate THEN codegen fails BECAUSE convex CLI reads `node_modules` for sub-component resolution -> LOW severity, mitigate by running codegen before removing deps.
+**The Real Question:** Confirmed — spec solves the right problem. The TS2589 is caused by stale generated types declaring 4 sub-components when only 1 exists. Removing the phantom declarations directly addresses the recursive `FilterApi` depth explosion.
+**Open Items:** [question] Should we run codegen before or after removing deps from package.json? -> explore (test both orders)
+
+## Notes
+
+### Ship Retro (2026-03-27)
+**Estimate vs Actual:** 1h -> 0.5h (200% accuracy)
+**What worked:** Root cause was immediately clear from diffing `convex.config.ts` (1 sub-component) vs `_generated/api.ts` (4 sub-components). Parallel discovery agents accelerated context gathering.
+**What didn't:** `pnpm build:codegen` requires a Convex deployment, so had to manually edit the generated file instead. Not a problem — the edit was trivial.
+**Next time:** For generated file fixes, check if codegen can run locally before planning it as the primary approach.
+
+## Timeline
+
+| Action | Timestamp | Duration | Notes |
+|--------|-----------|----------|-------|
+| plan | 2026-03-27T00:00:00Z | - | Created |
+| ship | 2026-03-27T00:10:00Z | 10m | Implemented |
+| review | 2026-03-27T00:15:00Z | 5m | CLEAN |
+| done | 2026-03-27T00:20:00Z | 20m | Shipped |

--- a/src/component/_generated/api.ts
+++ b/src/component/_generated/api.ts
@@ -50,8 +50,5 @@ export const internal: FilterApi<
 > = anyApi as any;
 
 export const components = componentsGeneric() as unknown as {
-  rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
   shardedCounter: import("@convex-dev/sharded-counter/_generated/component.js").ComponentApi<"shardedCounter">;
-  usageAggregate: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"usageAggregate">;
-  crons: import("@convex-dev/crons/_generated/component.js").ComponentApi<"crons">;
 };


### PR DESCRIPTION
## Summary

- Remove 3 stale `ComponentApi` imports from `src/component/_generated/api.ts` (`rateLimiter`, `usageAggregate`, `crons`) — left over from v0.2.0 which removed these sub-components but didn't regenerate the file
- Remove 3 phantom dependencies from `package.json` (`@convex-dev/rate-limiter`, `@convex-dev/aggregate`, `@convex-dev/crons`)
- Remove stale `rate-limiting` keyword

## Root Cause

`_generated/api.ts` declared 4 sub-component `ComponentApi` types when only `shardedCounter` exists. Each `ComponentApi` import adds a level of nesting through Convex's recursive `FilterApi` type. With 4 (3 phantom), host apps hit TypeScript's TS2589 depth limit when using `action()`/`query()` from `_generated/server`.

## Test Plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (82/82 tests)
- [x] Grep confirms zero source imports of removed packages
- [ ] Publish new version and verify host app typechecks cleanly

Closes #38