### PR TITLE
fix(ci): stop upgrading npm in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,9 +74,6 @@ jobs:
 
       - run: pnpm build
 
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
-
       - name: Publish canary
         run: |
           sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
@@ -166,9 +163,6 @@ jobs:
           git commit -m "chore(release): v${{ steps.version.outputs.version }}"
           git tag -a "v${{ steps.version.outputs.version }}" -m "v${{ steps.version.outputs.version }}"
           git push origin main --follow-tags
-
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
 
       - name: Publish to npm
         run: |


### PR DESCRIPTION
## Summary
- remove the `npm install -g npm@latest` step from the publish workflow
- use the npm bundled with `actions/setup-node@v4` instead of mutating the runner's global npm install
- unblock the canary/release publish jobs after the post-merge Publish workflow for PR #40 failed in the npm upgrade step

## Validation
- inspected the failed run: `Publish Canary` failed before publish with `MODULE_NOT_FOUND: promise-retry` while running `npm install -g npm@latest`
- verified the workflow diff is limited to removing the failing upgrade step

## Failure fixed
- failed run: https://github.com/vllnt/convex-api-keys/actions/runs/24930747023
