### PR TITLE
fix(ci): use github token for release checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ github.token }}
 
       - uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## Summary
- stop using `secrets.RELEASE_PAT` for release checkout
- use the workflow `github.token` with `contents: write` instead
- fix the manual release failure where checkout could not authenticate before the publish/tag steps ran

## Failure fixed
- failed release run: https://github.com/vllnt/convex-api-keys/actions/runs/24931027938
- failing step: `actions/checkout@v4`
- error: `fatal: could not read Username for 'https://github.com': terminal prompts disabled`
