### PR TITLE
docs: add Convex Component directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Convex Component](https://www.convex.dev/components/badge/vllnt/convex-api-keys)](https://www.convex.dev/components/vllnt/convex-api-keys)
 [![npm version](https://img.shields.io/npm/v/@vllnt/convex-api-keys)](https://www.npmjs.com/package/@vllnt/convex-api-keys)
 [![CI](https://github.com/vllnt/convex-api-keys/actions/workflows/ci.yml/badge.svg)](https://github.com/vllnt/convex-api-keys/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/@vllnt/convex-api-keys)](./LICENSE)


### PR DESCRIPTION
Adds the official Convex Component directory badge to the README badge block.

```
[![Convex Component](https://www.convex.dev/components/badge/vllnt/convex-api-keys)](https://www.convex.dev/components/vllnt/convex-api-keys)
```

Links to the component's listing on convex.dev/components. Placed first in the badge row (npm version, CI, License follow).